### PR TITLE
INT-4493 - Tenable_vulnerability_finding Enhancement request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+- add `last_fixed` property to `tenable_vulnerability_finding` entities.
+
+## [Unreleased]
+
 - refactor Container Security to v2 as v1 has been deprecated.
 - the following **new** entities have been added:
 

--- a/src/steps/vulnerabilities/converters.ts
+++ b/src/steps/vulnerabilities/converters.ts
@@ -345,6 +345,9 @@ export function createVulnerabilityEntity(
         // data model properties
         numericPriority,
         priority,
+        firstSeenOn: parseTimePropertyValue(vuln.first_found),
+        lastSeenOn: parseTimePropertyValue(vuln.last_found),
+        lastFixedOn: parseTimePropertyValue(vuln.last_fixed),
       },
     },
   });

--- a/src/tenable/client/types.ts
+++ b/src/tenable/client/types.ts
@@ -610,6 +610,7 @@ export interface VulnerabilityExport {
   severity_modification_type: string;
   first_found: string;
   last_found: string;
+  last_fixed?: string;
   state: string;
 }
 


### PR DESCRIPTION
This PR adds `last_fixed` property to `tenable_vulnerability_finding`.

Best merged/reviewed after #190 as running Tenable integration from main without any changes resulted in some error for the vulnerability step which got fixed in #190.