### PR TITLE
remove output property from raw data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 9.0.3 - 2023-02-03
+
+### Removed
+
+- removed the `output` property from the `rawData` of
+  `tenable_vulnerability_finding`
+
 ## 9.0.2 - 2023-01-26
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-tenable-io",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "description": "A JupiterOne managed integration for https://www.tenable.com/products/tenable-io",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/steps/vulnerabilities/converters.ts
+++ b/src/steps/vulnerabilities/converters.ts
@@ -264,6 +264,12 @@ export function createVulnerabilityEntity(
   } catch (err) {
     logger.warn({ err }, 'Encountered error when checking entity size');
   }
+  // The output property is often _very_ large.
+  // We may in the future come up with some use-cases for this property and may
+  // want to do some more fine-grained trimming of this property
+
+  delete vuln.output;
+
   return createIntegrationEntity({
     entityData: {
       source: vuln,

--- a/src/tenable/client/types.ts
+++ b/src/tenable/client/types.ts
@@ -600,7 +600,7 @@ export interface VulnerabilitiesExportStatusResponse {
 
 export interface VulnerabilityExport {
   asset: VulnerabilityExportAsset;
-  output: string | null;
+  output?: string | null;
   plugin: VulnerabilityExportPlugin;
   port: VulnerabilityExportPort;
   scan: VulnerabilityExportScan;


### PR DESCRIPTION
# Description

The output property is often very large and contributing to a lot of memory/disk usage. I've removed it from raw data.
In the future if we find some use for this proeprty we can do more fine-grained trimming.
