### PR TITLE
always log error in handle errror

### DIFF
--- a/src/tenable/TenableClient.ts
+++ b/src/tenable/TenableClient.ts
@@ -471,6 +471,7 @@ export default class TenableClient {
           return retryDelay;
         },
         handleError: (err, context) => {
+          this.logger.info({ err: { ...err } }, 'Encountered error from API');
           if (![429, 500, 504].includes(err.statusCode)) {
             context.abort();
           }


### PR DESCRIPTION
# Description

The bunyan logger does not serialize most properties on extended Errors. This log is here to make sure we can record and act on those properties.

I'm working seperately to fix this globally in the SDK.
