### PR TITLE
APP-15128 - Fetching more macAddresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .eslintcache
 tsconfig.tsbuildinfo
 .npmrc
+.idea


### PR DESCRIPTION
A `fqdns` is a "Fully Qualified" dns identifier.  It indicates that this device had a connection some sort of larger network, most commonly the internet. Any macAddresses used by this device over the internet can be considered unique (even though it isn't necessarily the case) because it is standard in the industry. This PR pulls adds those new `fqdns` macAddresses to the `macAddresses` property of the `tenable_asset` record.